### PR TITLE
修改injson/injson.py 中 if code in (1, 3, 5),缺少code=2的判断

### DIFF
--- a/injson.py
+++ b/injson.py
@@ -138,7 +138,7 @@ def check(sub, parent,  sp='/', pp='/'):
                     else:
                         re['result'] = dict(re['result'], **r['result'])
 
-            if code in (1, 3, 5):
+            if code !=0:
                 re['result'][sp + k] = {'code': code, 'sv': sv, 'pp': pp + k, 'pv': pv}
         else:  # 键不存在
             if var_flag:


### PR DESCRIPTION
在injson/injson.py 中，最后判断code值并且保存re['result'][sp+k],是缺少了对code=2的判断，会导致使用此类型值测试不通过：
test：
```
sub = {"code": 200,
       "data": "123",
       }

parent = {"code": 200,
          "data": {},
          }
```
修改：
`if code in (1, 3, 5):` 为 `if code !=0:`
源代码：
```
if code in (1, 3, 5):
                re['result'][sp + k] = {'code': code, 'sv': sv, 'pp': pp + k, 'pv': pv}
```